### PR TITLE
Add cache dir parameter

### DIFF
--- a/whisperspeech/a2wav.py
+++ b/whisperspeech/a2wav.py
@@ -11,11 +11,11 @@ import torchaudio
 
 # %% ../nbs/6. Quality-boosting vocoder.ipynb 2
 class Vocoder:
-    def __init__(self, repo_id="charactr/vocos-encodec-24khz", device=None):
+    def __init__(self, repo_id="charactr/vocos-encodec-24khz", device=None, cache_dir=None):
         if device is None: device = inference.get_compute_device()
         if device == 'mps': device = 'cpu' # mps does not currently work with vocos, thus only cuda or cpu
         self.device = device
-        self.vocos = Vocos.from_pretrained(repo_id).to(device)
+        self.vocos = Vocos.from_pretrained(repo_id, cache_dir=cache_dir).to(device)
 
     def is_notebook(self):
         try:

--- a/whisperspeech/a2wav.py
+++ b/whisperspeech/a2wav.py
@@ -15,7 +15,7 @@ class Vocoder:
         if device is None: device = inference.get_compute_device()
         if device == 'mps': device = 'cpu' # mps does not currently work with vocos, thus only cuda or cpu
         self.device = device
-        self.vocos = Vocos.from_pretrained(repo_id, cache_dir=cache_dir).to(device)
+        self.vocos = Vocos.from_pretrained(repo_id).to(device)
 
     def is_notebook(self):
         try:

--- a/whisperspeech/extract_metrics.py
+++ b/whisperspeech/extract_metrics.py
@@ -32,11 +32,12 @@ def prepare_metrics(
     input:str,  # audio file webdataset file path
     output:str, # output shard path
     n_samples:int=None, # process a limited amount of samples
+    cache_dir: str = None
     
 ):
     device = get_compute_device()
 
-    model = Model.from_pretrained(expanduser('~/.cache/brouhaha.ckpt'), strict=False)
+    model = Model.from_pretrained(expanduser('~/.cache/brouhaha.ckpt'), strict=False, cache_dir=cache_dir)
     snr_pipeline = RegressiveActivityDetectionPipeline(segmentation=model).to(torch.device(device))
         
     total = n_samples if n_samples else 'noinfer'

--- a/whisperspeech/extract_spk_emb.py
+++ b/whisperspeech/extract_spk_emb.py
@@ -42,6 +42,7 @@ def process_shard(
     output:str,         # output shard URL/path
     batch_size:int=16,        # batch size
     n_samples:int=None, # limit the number of samples (useful for quick benchmarking)
+    cache_dir: str = None
 ):
     device = get_compute_device()
     if n_samples is None: total = 'noinfer'
@@ -51,6 +52,7 @@ def process_shard(
     
     classifier = EncoderClassifier.from_hparams("speechbrain/spkrec-ecapa-voxceleb",
                                                 savedir=expanduser("~/.cache/speechbrain/"),
+                                                cache_dir=cache_dir,
                                                 run_opts = {"device": device})
     
     with utils.AtomicTarWriter(output) as sink:

--- a/whisperspeech/extract_stoks.py
+++ b/whisperspeech/extract_stoks.py
@@ -34,15 +34,17 @@ def prepare_stoks(
     n_samples:int=None, # process a limited amount of samples
     batch_size:int=64, # process several segments at once
     kind:str="max", # could be eqvad to get more uniform chunk lengths
+    cache_dir: str = None
     
 ):
     device = get_compute_device()
-    vq_model = vq_stoks.RQBottleneckTransformer.load_model(vq_model).to(device)
+    vq_model = vq_stoks.RQBottleneckTransformer.load_model(vq_model, cache_dir=cache_dir).to(device)
     vq_model.ensure_whisper()
     
     spk_classifier = EncoderClassifier.from_hparams("speechbrain/spkrec-ecapa-voxceleb",
                                                     savedir=expanduser("~/.cache/speechbrain/"),
-                                                    run_opts = {"device": device})
+                                                    run_opts = {"device": device},
+                                                   cache_dir=cache_dir)
     
     total = n_samples//batch_size if n_samples else 'noinfer'
 

--- a/whisperspeech/fetch_models.py
+++ b/whisperspeech/fetch_models.py
@@ -14,9 +14,9 @@ from os.path import expanduser
 import urllib.request
 
 # %% ../nbs/0. Download models.ipynb 3
-def load_whisperx(model, lang):
+def load_whisperx(model, lang, cache_dir=None):
     try:
-        whisperx.asr.load_model(model, "cpu", compute_type="float16", language=lang)
+        whisperx.asr.load_model(model, "cpu", compute_type="float16", language=lang, cache_dir=cache_dir)
     except ValueError as exc:
         print(exc.args[0])
         if exc.args[0] != "Requested float16 compute type, but the target device or backend do not support efficient float16 computation.":
@@ -24,15 +24,15 @@ def load_whisperx(model, lang):
 
 @call_parse
 def main():
-    EncodecModel.encodec_model_24khz()
-    whisper.load_model('base.en')
-    whisper.load_model('small.en')
-    whisper.load_model('medium')
-    whisperx.vad.load_vad_model('cpu')
-    load_whisperx('small.en', 'en')
-    load_whisperx('medium.en', 'en')
-    load_whisperx('medium', 'en')
-    load_whisperx('large-v3', 'en')
+    EncodecModel.encodec_model_24khz(cache_dir=cache_dir)
+    whisper.load_model('base.en', cache_dir=cache_dir)
+    whisper.load_model('small.en', cache_dir=cache_dir)
+    whisper.load_model('medium', cache_dir=cache_dir)
+    whisperx.vad.load_vad_model('cpu', cache_dir=cache_dir)
+    load_whisperx('small.en', 'en', cache_dir=cache_dir)
+    load_whisperx('medium.en', 'en', cache_dir=cache_dir)
+    load_whisperx('medium', 'en', cache_dir=cache_dir)
+    load_whisperx('large-v3', 'en', cache_dir=cache_dir)
     EncoderClassifier.from_hparams(source="speechbrain/spkrec-ecapa-voxceleb",
                                    savedir=expanduser("~/.cache/speechbrain/"))
     urllib.request.urlretrieve('https://github.com/marianne-m/brouhaha-vad/raw/main/models/best/checkpoints/best.ckpt',

--- a/whisperspeech/inference.py
+++ b/whisperspeech/inference.py
@@ -28,11 +28,11 @@ def get_compute_device():
     return preferred_device
 
 # %% ../nbs/D. Common inference utilities.ipynb 4
-def load_model(ref=None, spec=None, device='cpu'):
+def load_model(ref=None, spec=None, device='cpu', cache_dir=None):
     if spec is not None: return spec
     if ":" in ref:
         repo_id, filename = ref.split(":", 1)
-        local_filename = hf_hub_download(repo_id=repo_id, filename=filename)
+        local_filename = hf_hub_download(repo_id=repo_id, filename=filename, cache_dir=cache_dir)
     else:
         local_filename = ref
     return torch.load(local_filename, map_location=device)

--- a/whisperspeech/pipeline.py
+++ b/whisperspeech/pipeline.py
@@ -42,10 +42,10 @@ class Pipeline:
          0.2702,  0.1699, -0.1443, -0.9614,  0.3261,  0.1718,  0.3545, -0.0686]
     )
     
-    def __init__(self, t2s_ref=None, s2a_ref=None, optimize=True, torch_compile=False, device=None):
+    def __init__(self, t2s_ref=None, s2a_ref=None, optimize=True, torch_compile=False, device=None, cache_dir=None):
         if device is None: device = inference.get_compute_device()
         self.device = device
-        args = dict(device = device)
+        args = dict(device = device, cache_dir=cache_dir)
         try:
             if t2s_ref:
                 args["ref"] = t2s_ref
@@ -54,10 +54,10 @@ class Pipeline:
         except:
             print("Failed to load the T2S model:")
             print(traceback.format_exc())
-        args = dict(device = device)
+        args = dict(device = device, cache_dir=cache_dir)
         try:
             if s2a_ref:
-                spec = inference.load_model(ref=s2a_ref, device=device)
+                spec = inference.load_model(ref=s2a_ref, device=device, cache_dir=cache_dir)
                 if [x for x in spec['state_dict'].keys() if x.startswith('cond_embeddings.')]:
                     cls = s2a_delar_mup_wds_mlang_cond.SADelARTransformer
                     args['spec'] = spec

--- a/whisperspeech/s2a_delar_mup_wds_mlang.py
+++ b/whisperspeech/s2a_delar_mup_wds_mlang.py
@@ -411,14 +411,14 @@ class SADelARTransformer(nn.Module):
     #
     @classmethod
     def load_model(cls, ref="collabora/whisperspeech:s2a-q4-small-en+pl.model",
-                   repo_id=None, filename=None, local_filename=None, spec=None, device=None):
+                   repo_id=None, filename=None, local_filename=None, spec=None, device=None, cache_dir=None):
         if repo_id is None and filename is None and local_filename is None and spec is None:
             if ":" in ref:
                 repo_id, filename = ref.split(":", 1)
             else:
                 local_filename = ref
         if not local_filename and spec is None:
-            local_filename = hf_hub_download(repo_id=repo_id, filename=filename)
+            local_filename = hf_hub_download(repo_id=repo_id, filename=filename, cache_dir=cache_dir)
         if spec is None:
             spec = torch.load(local_filename, map_location=device)
         if '_extra_state' not in spec['state_dict'] and 'speaker_map' in spec['config']: spec['state_dict']['_extra_state'] = { 'speaker_map': spec['config']['speaker_map'] }

--- a/whisperspeech/t2s_up_wds_mlang_enclm.py
+++ b/whisperspeech/t2s_up_wds_mlang_enclm.py
@@ -353,14 +353,14 @@ class TSARTransformer(nn.Module):
     #
     @classmethod
     def load_model(cls, ref="collabora/whisperspeech:t2s-small-en+pl.model",
-                   repo_id=None, filename=None, local_filename=None, spec=None, device=None):
+                   repo_id=None, filename=None, local_filename=None, spec=None, device=None, cache_dir=None):
         if repo_id is None and filename is None and local_filename is None and spec is None:
             if ":" in ref:
                 repo_id, filename = ref.split(":", 1)
             else:
                 local_filename = ref
         if not local_filename and spec is None:
-            local_filename = hf_hub_download(repo_id=repo_id, filename=filename)
+            local_filename = hf_hub_download(repo_id=repo_id, filename=filename, cache_dir=cache_dir)
         if spec is None:
             spec = torch.load(local_filename, map_location=device)
         model = cls(**spec['config'], tunables=Tunables(**Tunables.upgrade(spec['tunables'])))

--- a/whisperspeech/utils.py
+++ b/whisperspeech/utils.py
@@ -23,6 +23,8 @@ def wrap_downloader(old):
         if os.environ.get('HUGGINGFACE_LOCAL_ONLY', False):
             print(f"Enforcing local_files_only for {old.__qualname__}")
             kwargs['local_files_only'] = True
+        if 'cache_dir' in kwargs:  # Added to ensure cache_dir is included
+            print(f"Using cache directory: {kwargs['cache_dir']}")
         return old(*args, **kwargs)
     return new
 

--- a/whisperspeech/vad.py
+++ b/whisperspeech/vad.py
@@ -67,6 +67,7 @@ def process_shard(
     output:str,          # output shard URL/path
     key:str='audio',     # string to replace with 'vad' in the shard name
     model:str='whisperx' # VAD model to use (possible values: `whisperx` or `pyannote`)
+    cache_dir: str = None
 ):  
     ds = wds.WebDataset(url).compose(
         wds.decode(utils.torch_audio_opus),
@@ -75,10 +76,10 @@ def process_shard(
     dl = torch.utils.data.DataLoader(ds, num_workers=1, batch_size=None)
     
     if model == 'whisperx':
-        vad_model = whisperx.vad.load_vad_model(get_compute_device())
+        vad_model = whisperx.vad.load_vad_model(get_compute_device(), cache_dir=cache_dir)
     elif model == 'pyannote':
         from pyannote.audio import Pipeline
-        pyannote_vad = Pipeline.from_pretrained("pyannote/voice-activity-detection")
+        pyannote_vad = Pipeline.from_pretrained("pyannote/voice-activity-detection", use_auth_token=None, cache_dir=cache_dir)
     
     def calc_power(audio, sr, ts, te):
         snd = audio[:,int(ts*sr):int(te*sr)]

--- a/whisperspeech/vq_stoks.py
+++ b/whisperspeech/vq_stoks.py
@@ -353,14 +353,14 @@ class RQBottleneckTransformer(nn.Module):
     #
     @classmethod
     def load_model(cls, ref="collabora/spear-tts-pytorch:whisper-vq-stoks-medium-en+pl.model",
-                   repo_id=None, filename=None, local_filename=None):
+                   repo_id=None, filename=None, local_filename=None, cache_dir=None):
         if repo_id is None and filename is None and local_filename is None:
             if ":" in ref:
                 repo_id, filename = ref.split(":", 1)
             else:
                 local_filename = ref
         if not local_filename:
-            local_filename = hf_hub_download(repo_id=repo_id, filename=filename)
+            local_filename = hf_hub_download(repo_id=repo_id, filename=filename, cache_dir=cache_dir)
         spec = torch.load(local_filename) 
         vqmodel = cls(**spec['config'], tunables=Tunables(**Tunables.upgrade(spec.get('tunables', {}))))
         vqmodel.load_state_dict(spec['state_dict'])

--- a/whisperspeech/wh_transcribe.py
+++ b/whisperspeech/wh_transcribe.py
@@ -114,6 +114,7 @@ def process_shard(
     n_samples:int=None, # limit the number of samples (useful for quick benchmarking)
     whisper_model:str="base.en", # Whisper model size
     language:str="en",  # transcription language
+    cache_dir: str = None
 ):
     device = get_compute_device()
     if output is None: output = flac_to_txt_name(input, whisper_model)
@@ -131,7 +132,7 @@ def process_shard(
     )
     dl = DataLoader(ds, num_workers=2, batch_size=None)
     
-    whmodel = whisper.load_model(whisper_model).to(device)
+    whmodel = whisper.load_model(whisper_model, cache_dir=cache_dir).to(device)
     decoding_options = whisper.DecodingOptions(language=language)
     
     tmp = output+".tmp"


### PR DESCRIPTION
The goal is to be able to specify the base directory in which all files downloaded from huggingface are downloaded instead of the default cache directory.

Some sample code might look like this:

```
from pathlib import Path

current_directory = Path(__file__).parent
CACHE_DIR = current_directory / "models" / "tts"
CACHE_DIR.mkdir(parents=True, exist_ok=True)

class BaseAudio:
.
.
.

class WhisperSpeechAudio(BaseAudio):
    def __init__(self):
        super().__init__()
        self.initialize_model()

    def initialize_model(self):

        self.pipe = Pipeline(
            s2a_ref='collabora/whisperspeech:s2a-q4-base-en+pl.model',
            t2s_ref='collabora/whisperspeech:t2s-base-en+pl.model',
            cache_dir=CACHE_DIR
        )
.
.
.
```