### PR TITLE
update version info and make webdataset mandatory

### DIFF
--- a/settings.ini
+++ b/settings.ini
@@ -5,7 +5,7 @@
 ### Python library ###
 repo = WhisperSpeech
 lib_name = %(repo)s
-version = 0.8
+version = 0.8.9
 min_python = 3.7
 license = MIT
 
@@ -36,10 +36,10 @@ status = 3
 user = collabora
 
 ### Optional ###
-requirements = vocos speechbrain<1.0 \
+requirements = vocos speechbrain<1.0 webdataset\
                requests huggingface_hub fastprogress fastcore \
                torch>=2 torchaudio soundfile
-dev_requirements = vector_quantize_pytorch==1.6.22 openai-whisper webdataset wandb \
+dev_requirements = vector_quantize_pytorch openai-whisper webdataset wandb \
 		   whisperx@git+https://github.com/m-bain/whisperx.git \
 		   whisper_normalizer jiwer \
 		   matplotlib pandas pyarrow scikit-learn ipython


### PR DESCRIPTION
pypi already shows version 0.8.9 so this will make it match.

also, making webdataset mandatory for non-dev as well as dev

This also unrestricted the vector_quantize_pytorch dependency version for dev purposes